### PR TITLE
Update index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
   <body>
 	<h1>Example Python Package Index</h1>
 	<section class="explanation">
-		<p>This is an example PyPy server, that is part of a ,a href="https://medium.freecodecamp.org/how-to-use-github-as-a-pypi-server-1c3b0d07db2">blog post on using GitHub (or other providers) as a PyPy Server</a></p>
+		<p>This is an example PyPy server, that is part of a <a href="https://medium.freecodecamp.org/how-to-use-github-as-a-pypi-server-1c3b0d07db2">blog post on using GitHub (or other providers) as a PyPy Server</a></p>
 		<p>This file isn't used by pip (at least in my version), although the <a href="https://www.python.org/dev/peps/pep-0503/">specification</a> states that it is (I have omitted the python_hello package and it still works). It is still useful from a discoverability point of view though, and future versions of Pip may require it.</p>
 		<p>Pip will look for directories using the normalised name of your package ('python-hello' in this case instead of 'python_hello'). More details in the <a href="https://www.python.org/dev/peps/pep-0503/#normalized-names">specification</a>.</p>
 	</section>


### PR DESCRIPTION
Here because of [this (enormously helpful!) post](https://www.freecodecamp.org/news/how-to-use-github-as-a-pypi-server-1c3b0d07db2/) which took me to your [mock package index page](https://ceddlyburge.github.io/python-package-server/) which had a simple `< -> ,` typo that broke the link back to your Medium post.

Just a simple PR to fix it, if you're so inclined :)